### PR TITLE
WIP:csharp should wrap python test too

### DIFF
--- a/examples/simple/dub.sdl
+++ b/examples/simple/dub.sdl
@@ -1,23 +1,49 @@
 name "simple"
-targetType "dynamicLibrary"
-dependency "autowrap:python" path="../../"
+
+configuration "csharp-buildlib" {
+    targetType "dynamicLibrary"
+    dependency "autowrap:csharp" path="../../"
+    versions "WrapCSharp"
+}
+
+configuration "csharp-emit" {
+    targetType "executable"
+    versions "EmitCSharp" "WrapCSharp"
+}
 
 configuration "python37" {
+    dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "python37"
+    targetType "dynamicLibrary"
+    versions "WrapPython"
 }
 
 configuration "python36" {
+    dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "python36"
+    targetType "dynamicLibrary"
+    versions "WrapPython"
 }
 
 configuration "python33" {
+    dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "python33"
+    targetType "dynamicLibrary"
+    versions "WrapPython"
 }
 
 configuration "python27" {
+    dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "python27"
+    targetType "dynamicLibrary"
+    versions "WrapPython"
 }
 
 configuration "env" {
+    dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "env"
+    targetType "dynamicLibrary"
+    versions "WrapPython"
 }
+
+

--- a/examples/simple/dub.sdl
+++ b/examples/simple/dub.sdl
@@ -11,6 +11,30 @@ configuration "csharp-emit" {
     versions "EmitCSharp" "WrapCSharp"
 }
 
+configuration "excel" {
+  preBuildCommands "dub run -c excel-def --nodeps -q -- simple.def"
+  sourceFiles "simple.def"
+  libs "xlcall32"
+  postBuildCommands "copy /y simple.dll simple.xll"
+  versions "WrapExcel"
+  dependency "excel-d" version="~master"
+}
+
+configuration "excel-def" {
+  targetType "executable"
+  targetName "simple"
+  versions "excelDef" "WrapExcel"
+  dependency "excel-d" version="~master"
+}
+
+configuration "excel-xll" {
+  sourceFiles "simple.def"
+  libs "xlcall32"
+  postBuildCommands "copy /y myxll.dll myxll.xll"
+  versions "WrapExcel"
+  dependency "excel-d" version="~master"
+}
+	
 configuration "python37" {
     dependency "autowrap:python" path="../../"
     subConfiguration "autowrap:python" "python37"

--- a/examples/simple/source/api.d
+++ b/examples/simple/source/api.d
@@ -1,10 +1,35 @@
-import std.datetime: DateTime, Date;
+version(WrapExcel)
+{
+	struct DateTime
+	{
+		int year,month,day,hour,minute,second;
+	}
+	struct Date
+	{
+		int year,month,day;
+	}
+}
+else
+{
+	import std.datetime: DateTime, Date;
+}
 
 import not_wrapped: NotWrappedInt;
 
-export auto createIntPoint(int x, int y) {
-    import templates: Point;
-    return Point!int(x, y);
+version(WrapExcel)
+{
+	// some kind of nogc inference problem
+	export auto createIntPoint()(int x, int y) {
+	    import templates: Point;
+	    return Point!int(x, y);
+	}
+}
+else
+{
+	export auto createIntPoint()(int x, int y) {
+	    import templates: Point;
+	    return Point!int(x, y);
+	}
 }
 
 export auto createIntString(int i, string s) {
@@ -15,10 +40,11 @@ export auto createIntString(int i, string s) {
 export auto createOuter(double x, double y, double value, string string1, string string2) {
     import templates;
     import structs: String;
+
     return Outer!double([
-                            Inner1!double(Point!double(x, y), value),
-                            Inner1!double(Point!double(x, y), value + 1),
-                        ],
+    				Inner1!double(Point!double(x, y), value),
+    				Inner1!double(Point!double(x, y), value+1),
+			],
                         Inner2!double(EvenInner!double(value)),
                         String(string1),
                         String(string2));
@@ -27,13 +53,13 @@ export auto createOuter(double x, double y, double value, string string1, string
 export auto createOuters(double x, double y, double value, string string1, string string2) {
     import templates;
     import structs: String;
-    return [Outer!double([
-                             Inner1!double(Point!double(x, y), value),
-                             Inner1!double(Point!double(x, y), value + 2)
-                         ],
-                        Inner2!double(EvenInner!double(value)),
-                        String(string1),
-                        String(string2))];
+    return Outer!double([
+				Inner1!double(Point!double(x,y),value),
+				Inner1!double(Point!double(x,y),value+2),
+			],
+			Inner2!double(EvenInner!double(value)),
+			String(string1),
+			String(string2));
 }
 
 

--- a/examples/simple/source/app.d
+++ b/examples/simple/source/app.d
@@ -28,3 +28,15 @@ version(WrapCSharp)
 	    )
 	);
 }
+
+version(WrapExcel)
+{
+	import xlld:wrapAll;
+
+	mixin(
+	    wrapAll!(
+		    "prefix", "adder", "structs", "templates", "api","wrap_all"
+		),
+        );
+}
+

--- a/examples/simple/source/app.d
+++ b/examples/simple/source/app.d
@@ -1,11 +1,30 @@
-import autowrap.python;
+version(WrapPython)
+{
+	import autowrap.python;
 
-mixin(
-    wrapAll(
-        LibraryName("simple"),
-        Modules(
-            "prefix", "adder", "structs", "templates", "api",
-            Module("wrap_all", Yes.alwaysExport)
-        ),
-    )
-);
+	mixin(
+	    wrapAll(
+		LibraryName("simple"),
+		Modules(
+		    "prefix", "adder", "structs", "templates", "api",
+		    Module("wrap_all", Yes.alwaysExport)
+		),
+	    )
+	);
+}
+
+version(WrapCSharp)
+{
+	import autowrap.csharp;
+	mixin(
+	    wrapCSharp(
+		Modules(
+		    "prefix", "adder", "structs", "templates", "api",
+		    Module("wrap_all") // , Yes.alwaysExport),
+		),
+		OutputFileName("simple.cs"),
+		LibraryName("simple"),
+		RootNamespace("simple")
+	    )
+	);
+}


### PR DESCRIPTION
Doesn't make sense to have different tests/examples for csharp and python!  This won't work right now because of bugs in csharp autowrap.  Had we used the same test/example we would have caught bugs earlier.