### PR TITLE
Disable csharp temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ env:
 
 script:
   - pynih/ci.sh
-  - DUB_CONFIGURATION=python37 make
+  - DUB_CONFIGURATION=python37 make test_python
   - dub run pyd:setup && source pyd_set_env_vars.sh
-  - DUB_CONFIGURATION=env make
+  - DUB_CONFIGURATION=env make test_python
   - dub test --build=unittest-cov --compiler=${DC}
   # - csharp/tests/test.sh  # disabled for now due to broken Microsoft repo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ install:
   - popd
   - source ~/dlang/${DC}/activate
   - pip install pytest numpy
-  - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
-  - sudo dpkg -i packages-microsoft-prod.deb
-  - sudo apt-get install apt-transport-https
-  - sudo apt-get update
-  - sudo apt-get install dotnet-sdk-2.1
+  # .NET core installation disabled for now due to broken Microsoft repo
+  # - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+  # - sudo dpkg -i packages-microsoft-prod.deb
+  # - sudo apt-get install apt-transport-https
+  # - sudo apt-get update
+  # - sudo apt-get install dotnet-sdk-2.1
 
 env:
   global:
@@ -37,7 +38,7 @@ script:
   - dub run pyd:setup && source pyd_set_env_vars.sh
   - DUB_CONFIGURATION=env make
   - dub test --build=unittest-cov --compiler=${DC}
-  - csharp/tests/test.sh
+  # - csharp/tests/test.sh  # disabled for now due to broken Microsoft repo
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The build (even on master) is broken right now because of the Microsoft .NET Ubuntu packages. So this disables C# testing on Travis for now while that's fixed.