### PR TITLE
Rework C# date/time support.

### DIFF
--- a/csharp/source/autowrap/csharp/Boilerplate.cs
+++ b/csharp/source/autowrap/csharp/Boilerplate.cs
@@ -87,32 +87,139 @@ namespace Autowrap {
 
     [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
     [StructLayout(LayoutKind.Sequential)]
-    internal struct datetime {
-        public datetime(long ticks, long offset) {
-            this._ticks = ticks;
-            this._offset = offset;
+    internal struct Marshalled_Duration {
+
+        public Marshalled_Duration(long hnsecs)
+        {
+            _hnsecs = hnsecs;
         }
-        public static implicit operator datetime(DateTime ret) { return new datetime(ret.Ticks, 0L); }
-        public static implicit operator datetime(DateTimeOffset ret) { return new datetime(ret.Ticks, ret.Offset.Ticks); }
-        public static implicit operator datetime(TimeSpan ret) { return new datetime(ret.Ticks, 0L); }
-        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Local); }
-        public static implicit operator DateTimeOffset(datetime ret) { return new DateTimeOffset(ret._ticks, new TimeSpan(ret._offset)); }
-        public static implicit operator TimeSpan(datetime ret) { return new TimeSpan(ret._ticks); }
-        private long _ticks;
-        private long _offset;
+
+        public static implicit operator Marshalled_Duration(TimeSpan val)
+        {
+            return new Marshalled_Duration(val.Ticks);
+        }
+
+        public static implicit operator TimeSpan(Marshalled_Duration val)
+        {
+            return TimeSpan.FromTicks(val._hnsecs);
+        }
+
+        private long _hnsecs;
     }
 
     [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
     [StructLayout(LayoutKind.Sequential)]
-    internal struct return_datetime_error {
+    internal struct return_Marshalled_Duration_error {
+
         private void EnsureValid() {
             var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
-            if (!string.IsNullOrEmpty(errStr)) throw new DLangException(errStr);
+            if (!string.IsNullOrEmpty(errStr))
+                throw new DLangException(errStr);
         }
-        public static implicit operator DateTime(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
-        public static implicit operator DateTimeOffset(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
-        public static implicit operator TimeSpan(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
-        private datetime _value;
+
+        public static implicit operator TimeSpan(return_Marshalled_Duration_error ret)
+        {
+            ret.EnsureValid(); return ret._value;
+        }
+
+        private Marshalled_Duration _value;
+        private slice _error;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Marshalled_std_datetime_date {
+
+        public Marshalled_std_datetime_date(DateTime dt)
+        {
+            _year = (short)dt.Year;
+            _month = (byte)dt.Month;
+            _day = (byte)dt.Day;
+            _hour = (byte)dt.Hour;
+            _minute = (byte)dt.Minute;
+            _second = (byte)dt.Second;
+        }
+
+        public static implicit operator Marshalled_std_datetime_date(DateTime val)
+        {
+            return new Marshalled_std_datetime_date(val);
+        }
+
+        public static implicit operator DateTime(Marshalled_std_datetime_date val)
+        {
+            return new DateTime(val._year, val._month, val._day,
+                                val._hour, val._minute, val._second,
+                                DateTimeKind.Utc);
+        }
+
+        short _year;
+        byte _month;
+        byte _day;
+        byte _hour;
+        byte _minute;
+        byte _second;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct return_Marshalled_std_datetime_date_error {
+
+        private void EnsureValid() {
+            var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
+            if (!string.IsNullOrEmpty(errStr))
+                throw new DLangException(errStr);
+        }
+
+        public static implicit operator DateTime(return_Marshalled_std_datetime_date_error ret)
+        {
+            ret.EnsureValid(); return ret._value;
+        }
+
+        private Marshalled_std_datetime_date _value;
+        private slice _error;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Marshalled_std_datetime_systime {
+
+        public Marshalled_std_datetime_systime(DateTimeOffset dto)
+        {
+            _ticks = dto.Ticks;
+            _utcOffset = dto.Offset.Ticks;
+        }
+
+        public static implicit operator Marshalled_std_datetime_systime(DateTimeOffset val)
+        {
+            return new Marshalled_std_datetime_systime(val);
+        }
+
+        public static implicit operator DateTimeOffset(Marshalled_std_datetime_systime val)
+        {
+            return new DateTimeOffset(val._ticks, TimeSpan.FromTicks(val._utcOffset));
+        }
+
+        private long _ticks;
+        private long _utcOffset;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct return_Marshalled_std_datetime_systime_error {
+
+        private void EnsureValid() {
+            var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
+            if (!string.IsNullOrEmpty(errStr))
+                throw new DLangException(errStr);
+        }
+
+        public static implicit operator DateTimeOffset(return_Marshalled_std_datetime_systime_error ret)
+        {
+            ret.EnsureValid();
+            return ret._value;
+        }
+
+        private Marshalled_std_datetime_systime _value;
         private slice _error;
     }
 

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -737,11 +737,11 @@ private string getDLangInterfaceType(T, Parent...)()
         case stringTypeString: return "slice";
         case wstringTypeString: return "slice";
         case dstringTypeString: return "slice";
-        case sysTimeTypeString: return "datetime";
-        case dateTimeTypeString: return "datetime";
-        case timeOfDayTypeString: return "datetime";
-        case dateTypeString: return "datetime";
-        case durationTypeString: return "datetime";
+        case sysTimeTypeString: return "Marshalled_std_datetime_systime";
+        case dateTimeTypeString: return "Marshalled_std_datetime_date";
+        case timeOfDayTypeString: return "Marshalled_std_datetime_date";
+        case dateTypeString: return "Marshalled_std_datetime_date";
+        case durationTypeString: return "Marshalled_Duration";
         case boolTypeString: return "bool";
 
         //Types that can be marshalled by default
@@ -853,15 +853,15 @@ private string getCSharpMethodInterfaceName(string aggName, string funcName) {
     import std.string : split;
     import std.string : replace;
 
-    if (aggName == "DateTime" || aggName == "DateTimeOffset" || aggName == "TimeSpan") {
+    if (aggName == "DateTime" || aggName == "DateTimeOffset" || aggName == "TimeSpan")
         aggName = "Datetime";
-    }
 
-    string name = string.init;
-    if (aggName !is null && aggName != string.init) {
+    string name;
+    if (aggName !is null && aggName != string.init)
         name ~= camelToPascalCase(aggName) ~ "_";
-    }
+
     name ~= camelToPascalCase(funcName);
+
     return name.replace(".", "_");
 }
 

--- a/csharp/tests/Functions.cs
+++ b/csharp/tests/Functions.cs
@@ -8,7 +8,7 @@ namespace Autowrap.CSharp.Tests
     [TestClass]
     public class Functions
     {
-        public Functions() {
+        static Functions() {
             SharedFunctions.DRuntimeInitialize();
         }
 

--- a/csharp/tests/test.sh
+++ b/csharp/tests/test.sh
@@ -5,6 +5,7 @@ CWD=$PWD
 
 cd $DIR
 
+rm -f Wrapper.cs libcsharp-tests.so libcsharp-tests.x64.so
 dub build --arch=x86_64 --force
 cp libcsharp-tests.so libcsharp-tests.x64.so
 dub run --config=emitCSharp

--- a/tests/test_simple_cs/TestSimple.cs
+++ b/tests/test_simple_cs/TestSimple.cs
@@ -71,15 +71,19 @@ namespace Autowrap.CSharp.Examples.Simple.Tests
         }
 
         [TestMethod]
-        public void TestCreateDatetime()
+        public void TestCreateDateTime()
         {
-            // TODO: The way that autowrap's C# handles std.datetime is error-prone and needs to be changed
+            var d = Api.Functions.CreateDateTime(2017, 1, 2);
+            Assert.AreEqual(d.Year, 2017);
+            Assert.AreEqual(d.Month, 1);
+            Assert.AreEqual(d.Day, 2);
         }
 
         [TestMethod]
-        public void TestCreateDatetimeArray()
+        public void TestCreateDateTimeArray()
         {
-            // TODO: The way that autowrap's C# handles std.datetime is error-prone and needs to be changed
+            // TODO: Aside from arrays of strings, arrays of arrays are not yet supported,
+            //       and points returns DateTime[][]
         }
 
         [TestMethod]
@@ -93,7 +97,6 @@ namespace Autowrap.CSharp.Examples.Simple.Tests
         public void TestTupleofDateTimes()
         {
             // TODO: Templated type support still needs to be added to autowrap's C#
-            // TODO: The way that autowrap's C# handles std.datetime is error-prone and needs to be changed
         }
 
         [TestMethod]
@@ -111,7 +114,10 @@ namespace Autowrap.CSharp.Examples.Simple.Tests
         [TestMethod]
         public void TestCreateDate()
         {
-            // TODO: The way that autowrap's C# handles std.datetime is error-prone and needs to be changed
+            var d = Api.Functions.CreateDate(2017, 1, 2);
+            Assert.AreEqual(d.Year, 2017);
+            Assert.AreEqual(d.Month, 1);
+            Assert.AreEqual(d.Day, 2);
         }
 
         [TestMethod]
@@ -155,7 +161,8 @@ namespace Autowrap.CSharp.Examples.Simple.Tests
         [TestMethod]
         public void TestTheYear()
         {
-            // TODO: The way that autowrap's C# handles std.datetime is error-prone and needs to be changed
+            Assert.AreEqual(Api.Functions.TheYear(new DateTime(2017, 1, 1)), 2017);
+            Assert.AreEqual(Api.Functions.TheYear(new DateTime(2018, 2, 3)), 2018);
         }
 
         [TestMethod]


### PR DESCRIPTION
The way it was before was going to cause subtle problems. Now, there are
three different marshalling types for the date/time types - one for
Duration, one for Date, TimeOfDay, and DateTime, and one for SysTime.
Duration gets converted to TimeSpan. D's Date, TimeOfDay, and DateTime
get converted to C#'s DateTime with DateTimeKind.Utc. And SysTime gets
converted to DateTimeOffset.

For C#'s DateTime, the conversion between ticks and the year, month,
day, etc. properties is now done in C# so that what D considers those
properties to be will always match what C# considers them to be.