### PR TITLE
Refactor createPythonModuleMixin

### DIFF
--- a/common/source/autowrap/types.d
+++ b/common/source/autowrap/types.d
@@ -1,0 +1,75 @@
+/**
+   Types to be used in the API for type-safety
+   (as opposed to, say, raw strings).
+ */
+module autowrap.types;
+
+
+template isModule(alias T) {
+    import std.traits: Unqual;
+    enum isModule = is(Unqual!(typeof(T)) == Module);
+}
+
+
+/**
+   The list of modules to automatically wrap for consumption by other languages.
+ */
+struct Modules {
+    import std.traits: Unqual;
+    import std.meta: allSatisfy;
+
+    Module[] value;
+
+    this(A...)(auto ref A modules) {
+
+        foreach(module_; modules) {
+            static if(is(Unqual!(typeof(module_)) == Module))
+                value ~= module_;
+            else static if(is(Unqual!(typeof(module_)) == string))
+                value ~= Module(module_);
+            else
+                static assert(false, "Modules must either be `string` or `Module`");
+        }
+    }
+}
+
+/**
+   A module to automatically wrap.
+   Usually not needed since a string will do, but is useful when trying to export
+   all functions from a module by using Module("mymodule", Yes.alwaysExport)
+   instead of "mymodule"
+ */
+struct Module {
+    import std.typecons: Flag, No;
+
+    string name;
+    Flag!"alwaysExport" alwaysExport = No.alwaysExport;
+
+    string toString() @safe pure const {
+        import std.conv: text;
+        import std.string: capitalize;
+        return text(`Module("`, name, `", `, text(alwaysExport).capitalize, `.alwaysExport)`);
+    }
+}
+
+
+/**
+   The name of the dynamic library, i.e. the file name with the .so/.dll extension
+ */
+struct LibraryName {
+    string value;
+}
+
+/**
+   Code to be inserted before the call to module_init
+ */
+struct PreModuleInitCode {
+    string value;
+}
+
+/**
+   Code to be inserted after the call to module_init
+ */
+struct PostModuleInitCode {
+    string value;
+}

--- a/pynih/source/autowrap/pynih/wrap.d
+++ b/pynih/source/autowrap/pynih/wrap.d
@@ -6,31 +6,10 @@ module autowrap.pynih.wrap;
 
 public import std.typecons: Yes, No;
 public import autowrap.reflection: Modules, Module, isModule;
+public import autowrap.types: LibraryName, PreModuleInitCode, PostModuleInitCode;
 static import python.boilerplate;
 import python.raw: isPython2, isPython3;
 import std.meta: allSatisfy;
-
-
-/**
-   The name of the dynamic library, i.e. the file name with the .so/.dll extension
- */
-struct LibraryName {
-    string value;
-}
-
-/**
-   Not used. Included for compatibility with the pyd backend.
- */
-struct PreModuleInitCode {
-    string value;
-}
-
-/**
-   Not used. Included for compatibility with the pyd backend.
- */
-struct PostModuleInitCode {
-    string value;
-}
 
 
 /**

--- a/pynih/source/autowrap/pynih/wrap.d
+++ b/pynih/source/autowrap/pynih/wrap.d
@@ -19,14 +19,14 @@ struct LibraryName {
 }
 
 /**
-   Code to be inserted before the call to module_init
+   Not used. Included for compatibility with the pyd backend.
  */
 struct PreModuleInitCode {
     string value;
 }
 
 /**
-   Code to be inserted after the call to module_init
+   Not used. Included for compatibility with the pyd backend.
  */
 struct PostModuleInitCode {
     string value;

--- a/python/source/autowrap/python/boilerplate.d
+++ b/python/source/autowrap/python/boilerplate.d
@@ -10,28 +10,9 @@
  */
 module autowrap.python.boilerplate;
 
+
+public import autowrap.types: LibraryName, PreModuleInitCode, PostModuleInitCode;
 import autowrap.reflection : Modules;
-
-/**
-   The name of the dynamic library, i.e. the file name with the .so/.dll extension
- */
-struct LibraryName {
-    string value;
-}
-
-/**
-   Code to be inserted before the call to module_init
- */
-struct PreModuleInitCode {
-    string value;
-}
-
-/**
-   Code to be inserted after the call to module_init
- */
-struct PostModuleInitCode {
-    string value;
-}
 
 
 /**

--- a/python/source/autowrap/python/boilerplate.d
+++ b/python/source/autowrap/python/boilerplate.d
@@ -46,9 +46,9 @@ string wrapDlang(
     PostModuleInitCode postModuleInitCode = PostModuleInitCode())
     ()
 {
-    return !__ctfe
-        ? null
-        : wrapAll(libraryName, modules, preModuleInitCode, postModuleInitCode);
+    return __ctfe
+        ? wrapAll(libraryName, modules, preModuleInitCode, postModuleInitCode)
+        : null;
 }
 
 

--- a/reflection/dub.sdl
+++ b/reflection/dub.sdl
@@ -3,3 +3,5 @@ description "Reflect on modules to access functions and data types"
 authors "Atila Neves"
 license "BSD"
 targetType "library"
+
+dependency "autowrap:common" path="../common"

--- a/reflection/source/autowrap/reflection.d
+++ b/reflection/source/autowrap/reflection.d
@@ -1,62 +1,14 @@
 module autowrap.reflection;
 
 
+public import autowrap.types: isModule, Modules, Module;
 import std.meta: allSatisfy;
 import std.traits: isArray, isCallable;
 import std.typecons: Flag, No;
 
 
-template isModule(alias T) {
-    import std.traits: Unqual;
-    enum isModule = is(Unqual!(typeof(T)) == Module);
-}
-
-
 private alias I(alias T) = T;
 private enum isString(alias T) = is(typeof(T) == string);
-
-
-/**
-   The list of modules to automatically wrap for consumption by other languages.
- */
-struct Modules {
-    import autowrap.reflection: Module;
-    import std.traits: Unqual;
-    import std.meta: allSatisfy;
-
-    Module[] value;
-
-    this(A...)(auto ref A modules) {
-
-        foreach(module_; modules) {
-            static if(is(Unqual!(typeof(module_)) == Module))
-                value ~= module_;
-            else static if(is(Unqual!(typeof(module_)) == string))
-                value ~= Module(module_);
-            else
-                static assert(false, "Modules must either be `string` or `Module`");
-        }
-    }
-}
-
-/**
-   A module to automatically wrap.
-   Usually not needed since a string will do, but is useful when trying to export
-   all functions from a module by using Module("mymodule", Yes.alwaysExport)
-   instead of "mymodule"
- */
-struct Module {
-    import std.typecons: Flag, No;
-
-    string name;
-    Flag!"alwaysExport" alwaysExport = No.alwaysExport;
-
-    string toString() @safe pure const {
-        import std.conv: text;
-        import std.string: capitalize;
-        return text(`Module("`, name, `", `, text(alwaysExport).capitalize, `.alwaysExport)`);
-    }
-}
 
 
 template AllFunctions(Modules modules) {

--- a/reflection/source/autowrap/reflection.d
+++ b/reflection/source/autowrap/reflection.d
@@ -2,13 +2,19 @@ module autowrap.reflection;
 
 
 import std.meta: allSatisfy;
-import std.traits: isArray, Unqual, moduleName, isCallable;
+import std.traits: isArray, isCallable;
 import std.typecons: Flag, No;
+
+
+template isModule(alias T) {
+    import std.traits: Unqual;
+    enum isModule = is(Unqual!(typeof(T)) == Module);
+}
 
 
 private alias I(alias T) = T;
 private enum isString(alias T) = is(typeof(T) == string);
-enum isModule(alias T) = is(Unqual!(typeof(T)) == Module);
+
 
 /**
    The list of modules to automatically wrap for consumption by other languages.


### PR DESCRIPTION
Replaces a convoluted mixin that transforms templates into strings to be mixed in (what was I thinking?) into a more straightforward implementation.