### PR TITLE
Fix autowrap.reflection imports

### DIFF
--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -10,17 +10,10 @@
  */
 module autowrap.csharp.boilerplate;
 
-import autowrap.common;
-import autowrap.reflection;
-import autowrap.csharp;
 
-import core.time;
-import core.memory;
-import std.conv;
-import std.traits : Unqual;
-import std.string;
-import std.traits;
-import std.utf;
+import autowrap.types: Modules;
+import autowrap.csharp.common: OutputFileName, LibraryName, RootNamespace;
+
 
 private void pinInternalPointers(T)(ref T value) @trusted nothrow
     if(is(T == struct))
@@ -48,6 +41,9 @@ private void pinInternalPointers(T)(ref T value) @trusted nothrow
 }
 
 extern(C) export struct returnValue(T) {
+
+    import std.traits: isDynamicArray;
+
     T value;
     wstring error;
 
@@ -68,6 +64,8 @@ extern(C) export struct returnValue(T) {
     }
 
     this(Exception error) nothrow {
+        import std.conv: to;
+
         this.value = T.init;
         try {
             this.error = to!wstring(error.toString());
@@ -79,6 +77,8 @@ extern(C) export struct returnValue(T) {
 }
 
 extern(C) export struct returnVoid {
+    import std.conv: to;
+
     wstring error = null;
 
     this(Exception error) nothrow {
@@ -128,6 +128,7 @@ extern(C) export struct Marshalled_Duration {
 extern(C) export struct Marshalled_std_datetime_date {
 
     import std.datetime.date : Date, DateTime, TimeOfDay;
+    import std.traits: Unqual;
 
     // = 1 so that the result is a valid C# DateTime when the D type is Date
     short year = 1;
@@ -218,6 +219,7 @@ public auto mapArray(alias pred, T)(T[] arr)
 }
 
 public void pinPointer(void* ptr) nothrow {
+    import core.memory: GC;
     GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
     GC.addRoot(ptr);
 }
@@ -272,7 +274,7 @@ public string wrapCSharp(in Modules modules, OutputFileName outputFile, LibraryN
     import std.format : format;
     import std.algorithm: map;
     import std.array: join;
-    import autowrap.common;
+    import autowrap.common: dllMainMixinStr;
     import autowrap.csharp.boilerplate;
 
     if(!__ctfe) return null;

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -3,7 +3,7 @@ module autowrap.csharp.csharp;
 import scriptlike : interp, _interp_text;
 
 import autowrap.csharp.common : LibraryName, RootNamespace, OutputFileName;
-import autowrap.reflection : isModule, Modules;
+import autowrap.types : isModule, Modules;
 
 import std.ascii : newline;
 import std.meta: allSatisfy;

--- a/csharp/source/autowrap/csharp/dlang.d
+++ b/csharp/source/autowrap/csharp/dlang.d
@@ -8,7 +8,8 @@ import std.meta : allSatisfy;
 import std.range.primitives;
 
 import autowrap.csharp.boilerplate;
-import autowrap.reflection : isModule, PrimordialType;
+import autowrap.types : isModule;
+import autowrap.reflection: PrimordialType;
 
 enum string methodSetup = "        auto attachThread = AttachThread.create();";
 

--- a/csharp/source/autowrap/csharp/package.d
+++ b/csharp/source/autowrap/csharp/package.d
@@ -1,6 +1,6 @@
 module autowrap.csharp;
 
-public import autowrap.reflection : Modules, Module;
+public import autowrap.types : Modules, Module;
 public import autowrap.csharp.boilerplate;
 public import autowrap.csharp.csharp;
 public import autowrap.csharp.dlang;

--- a/csharp/tests/test.sh
+++ b/csharp/tests/test.sh
@@ -6,8 +6,8 @@ CWD=$PWD
 cd $DIR
 
 rm -f Wrapper.cs libcsharp-tests.so libcsharp-tests.x64.so
-dub build --arch=x86_64 --force
+dub build -q --arch=x86_64
 cp libcsharp-tests.so libcsharp-tests.x64.so
-dub run --config=emitCSharp
+dub run -q --config=emitCSharp
 dotnet build
 dotnet test

--- a/pynih/source/autowrap/pynih/wrap.d
+++ b/pynih/source/autowrap/pynih/wrap.d
@@ -5,8 +5,8 @@ module autowrap.pynih.wrap;
 
 
 public import std.typecons: Yes, No;
-public import autowrap.reflection: Modules, Module, isModule;
-public import autowrap.types: LibraryName, PreModuleInitCode, PostModuleInitCode;
+public import autowrap.types: Modules, Module, isModule,
+    LibraryName, PreModuleInitCode, PostModuleInitCode;
 static import python.boilerplate;
 import python.raw: isPython2, isPython3;
 import std.meta: allSatisfy;
@@ -51,7 +51,7 @@ string createPythonModuleMixin(LibraryName libraryName, Modules modules)
 
         extern(C) export auto %s() { // -> ModuleInitRet
             import autowrap.pynih.wrap: createPythonModule, LibraryName;
-            import autowrap.reflection: Module;
+            import autowrap.types: Module;
             return createPythonModule!(
                 LibraryName("%s"),
                 %s

--- a/python/source/autowrap/python/boilerplate.d
+++ b/python/source/autowrap/python/boilerplate.d
@@ -11,8 +11,7 @@
 module autowrap.python.boilerplate;
 
 
-public import autowrap.types: LibraryName, PreModuleInitCode, PostModuleInitCode;
-import autowrap.reflection : Modules;
+public import autowrap.types: Modules, LibraryName, PreModuleInitCode, PostModuleInitCode;
 
 
 /**

--- a/python/source/autowrap/python/package.d
+++ b/python/source/autowrap/python/package.d
@@ -4,5 +4,5 @@
 module autowrap.python;
 
 public import autowrap.python.boilerplate;
-public import autowrap.reflection: Modules, Module;
+public import autowrap.types: Modules, Module;
 public import std.typecons: Yes, No;

--- a/python/source/autowrap/python/wrap.d
+++ b/python/source/autowrap/python/wrap.d
@@ -6,7 +6,8 @@
  */
 module autowrap.python.wrap;
 
-import autowrap.reflection: isUserAggregate, isModule;
+import autowrap.types: isModule;
+import autowrap.reflection: isUserAggregate;
 import std.meta: allSatisfy;
 import std.traits: isArray;
 

--- a/tests/ut/issues.d
+++ b/tests/ut/issues.d
@@ -3,7 +3,8 @@ module issues;
 
 @("24")
 @safe pure unittest {
-    import autowrap.reflection;
+    import autowrap.types: Module;
+    import autowrap.reflection: AllFunctions, AllAggregates;
     import std.typecons: Yes;
     import std.traits: fullyQualifiedName;
     import std.meta: staticMap, AliasSeq;


### PR DESCRIPTION
Some of what was in autowrap.reflection got moved to autowrap.types.
Nothing broke via the magic of public imports, but this commit
imports the necessary types via the correct package/module name.