### PR TITLE
First attempt to try and wrap std.socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 export PYTHON_LIB_DIR ?= /usr/lib
 DUB_CONFIGURATION ?= python37
 
-.PHONY: clean test test_python test_cs test_simple_pyd test_simple_pynih test_simple_cs test_pyd_pyd test_issues_pyd test_issues_pynih test_numpy_pyd test_numpy_pynih examples/simple/lib/pyd/libsimple.so examples/simple/lib/pynih/libsimple.so examples/issues/lib/pyd/libissues.so examples/issues/lib/pynih/libissues.so examples/numpy/lib/pyd/libnumpy.so examples/numpy/lib/pynih/libnumpy.so examples/pyd/lib/pyd/libpydtests.so examples/pyd/lib/pynih/libpydtests.so
+.PHONY: clean test test_python test_cs test_simple_pyd test_simple_pynih test_simple_cs test_pyd_pyd test_issues_pyd test_issues_pynih test_numpy_pyd test_numpy_pynih examples/simple/lib/pyd/libsimple.so examples/simple/lib/pynih/libsimple.so examples/issues/lib/pyd/libissues.so examples/issues/lib/pynih/libissues.so examples/numpy/lib/pyd/libnumpy.so examples/numpy/lib/pynih/libnumpy.so examples/pyd/lib/pyd/libpydtests.so examples/pyd/lib/pynih/libpydtests.so examples/phobos/lib/pyd/libphobos.so examples/phobos/lib/pynih/libphobos.so
 
 all: test
 test: test_python test_cs
@@ -104,6 +104,7 @@ examples/pyd/lib/pynih/pyd.so: examples/pyd/lib/pynih/libpydtests.so
 examples/pyd/lib/pynih/libpydtests.so: pynih/source/python/raw.d
 	@cd examples/pyd && dub build -q -c pynih
 
+
 test_numpy_pyd: tests/test_numpy.py examples/numpy/lib/pyd/numpytests.so
 	PYTHONPATH=$(PWD)/examples/numpy/lib/pyd pytest -s -vv $<
 
@@ -125,5 +126,24 @@ examples/numpy/lib/pynih/numpytests.so: examples/numpy/lib/pynih/libnumpy.so
 examples/numpy/lib/pynih/libnumpy.so: pynih/source/python/raw.d
 	@cd examples/numpy && dub build -q -c pynih
 
-examples/numpy/dub.selections.json:
-	@cd examples/numpy && dub upgrade -q
+
+test_phobos_pyd: tests/test_phobos.py examples/phobos/lib/pyd/phobos.so
+	PYTHONPATH=$(PWD)/examples/phobos/lib/pyd pytest -s -vv $<
+
+examples/phobos/lib/pyd/phobos.so: examples/phobos/lib/pyd/libphobos.so
+	@cp $^ $@
+
+examples/phobos/lib/pyd/libphobos.so:
+	@cd examples/phobos && dub build -q -c $(DUB_CONFIGURATION)
+
+examples/phobos/dub.selections.json:
+	@cd examples/phobos && dub upgrade -q
+
+test_phobos_pynih: tests/test_phobos.py examples/phobos/lib/pynih/phobos.so
+	PYTHONPATH=$(PWD)/examples/phobos/lib/pynih pytest -s -vv $<
+
+examples/phobos/lib/pynih/phobos.so: examples/phobos/lib/pynih/libphobos.so
+	@cp $^ $@
+
+examples/phobos/lib/pynih/libphobos.so: pynih/source/python/raw.d
+	@cd examples/phobos && dub build -q -c pynih

--- a/examples/phobos/dub.sdl
+++ b/examples/phobos/dub.sdl
@@ -1,0 +1,40 @@
+name "phobos"
+targetType "dynamicLibrary"
+
+
+configuration "python37" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python37"
+}
+
+configuration "python36" {
+    targetPath "lib/pyd"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python36"
+}
+
+configuration "python33" {
+    targetPath "lib/pyd"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python33"
+}
+
+configuration "python27" {
+    targetPath "lib/pyd"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python27"
+}
+
+configuration "env" {
+    targetPath "lib/pyd"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "env"
+}
+
+configuration "pynih" {
+    targetPath "lib/pynih"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:pynih" path="../../"
+}

--- a/examples/phobos/dub.selections.json
+++ b/examples/phobos/dub.selections.json
@@ -1,0 +1,9 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"autowrap": {"path":"../../"},
+		"mirror": "0.0.8",
+		"pyd": "0.11.0",
+		"unit-threaded": "0.10.4"
+	}
+}

--- a/examples/phobos/source/app.d
+++ b/examples/phobos/source/app.d
@@ -11,5 +11,6 @@ enum str = wrapDlang!(
         Module("std.socket", Yes.alwaysExport),
     ),
 );
+
 // pragma(msg, str);
 mixin(str);

--- a/examples/phobos/source/app.d
+++ b/examples/phobos/source/app.d
@@ -1,0 +1,15 @@
+version(Have_autowrap_pynih)
+    import autowrap.pynih;
+else version(Have_autowrap_csharp)
+    import autowrap.csharp;
+else
+    import autowrap.python;
+
+enum str = wrapDlang!(
+    LibraryName("phobos"),
+    Modules(
+        Module("std.socket", Yes.alwaysExport),
+    ),
+);
+// pragma(msg, str);
+mixin(str);

--- a/pynih/source/python/cooked.d
+++ b/pynih/source/python/cooked.d
@@ -3,8 +3,10 @@
  */
 module python.cooked;
 
+
 import python.raw;
 import python.boilerplate: Module, CFunctions, Aggregates;
+
 
 /**
    Creates a Python3 module from the given C functions.
@@ -25,7 +27,6 @@ auto createModule(Module module_, alias cfunctions, alias aggregates)()
 
     return module_;
 }
-
 
 
 /**

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -211,8 +211,15 @@ struct PythonType(T) {
         import std.traits: isFunction, ReturnType;
 
         static if(is(T == struct)) {
-            enum isPublic(string memberName) =
-                __traits(getProtection, __traits(getMember, T, memberName)) == "public";
+
+            template isPublic(string memberName) {
+                alias member = __traits(getMember, T, memberName);
+                static if(__traits(compiles, __traits(getProtection, member)))
+                    enum isPublic = __traits(getProtection, member) == "public";
+                else
+                    enum isPublic = false;
+            }
+
             alias publicMemberNames = Filter!(isPublic, __traits(allMembers, T));
             alias AggMember(string memberName) = Alias!(__traits(getMember, T, memberName));
             alias members = staticMap!(AggMember, publicMemberNames);

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -295,8 +295,14 @@ struct PythonType(T) {
             else
                 enum flags = defaultMethodFlags;
 
-            methods[i] = pyMethodDef!(__traits(identifier, memberFunction), flags)
-                                     (&PythonMethod!(T, memberFunction)._py_method_impl);
+            static if(__traits(compiles, &PythonMethod!(T, memberFunction)._py_method_impl))
+                methods[i] = pyMethodDef!(__traits(identifier, memberFunction), flags)
+                                         (&PythonMethod!(T, memberFunction)._py_method_impl);
+            else {
+                pragma(msg, "WARNING: could not wrap D method `", T, ".", __traits(identifier, memberFunction), "`");
+                // uncomment to get the compiler error message to find out why not
+                // auto ptr = &PythonMethod!(T, memberFunction)._py_method_impl;
+            }
         }}
 
         return &methods[0];

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -481,11 +481,19 @@ private auto pythonArgsToDArgs(bool isVariadic, P...)(PyObject* args, PyObject* 
 
     void positional(size_t i, T)() {
         auto item = PyTuple_GetItem(args, i);
-        if(!checkPythonType!T(item)) {
-            import python.raw: PyErr_Clear;
-            PyErr_Clear;
-            throw new ArgumentConversionException("Can't convert to " ~ T.stringof);
+
+        static if(__traits(compiles, checkPythonType!T(item))) {
+            if(!checkPythonType!T(item)) {
+                import python.raw: PyErr_Clear;
+                PyErr_Clear;
+                throw new ArgumentConversionException("Can't convert to " ~ T.stringof);
+            }
+        } else {
+            pragma(msg, "WARNING: cannot check python type for `", T, "`");
+            // uncomment to see the compilation error
+            // checkPythonType!T(item);
         }
+
         dArgs[i] = item.to!T;
     }
 

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -247,8 +247,8 @@ struct PythonType(T) {
         static foreach(i; 0 .. fieldNames.length) {
             getsets[i].name = cast(typeof(PyGetSetDef.name)) fieldNames[i];
             static if(__traits(getProtection, __traits(getMember, T, fieldNames[i])) == "public") {
-                getsets[i].get = &PythonClass!T.get!i;
-                getsets[i].set = &PythonClass!T.set!i;
+                getsets[i].get = &PythonClass!T._get_impl!i;
+                getsets[i].set = &PythonClass!T._set_impl!i;
             }
         }
 
@@ -557,7 +557,7 @@ private void mutateSelf(T)(PyObject* self, auto ref T dAggregate) {
 
     static foreach(i; 0 .. PythonClass!T.fieldNames.length) {
         if(self !is null)
-            pyClassSelf.set!i(self, pyClassNewSelf.get!i(newSelf));
+            pyClassSelf._set_impl!i(self, pyClassNewSelf._get_impl!i(newSelf));
     }
 
 }
@@ -827,8 +827,8 @@ struct PythonClass(T) if(isUserAggregate!T) {
     }
 
     // The function pointer for PyGetSetDef.get
-    private static extern(C) PyObject* get(int FieldIndex)
-                                          (PyObject* self_, void* closure = null)
+    private static extern(C) PyObject* _get_impl(int FieldIndex)
+                                                (PyObject* self_, void* closure = null)
         nothrow
         in(self_ !is null)
     {
@@ -844,8 +844,8 @@ struct PythonClass(T) if(isUserAggregate!T) {
     }
 
     // The function pointer for PyGetSetDef.set
-    static extern(C) int set(int FieldIndex)
-                            (PyObject* self_, PyObject* value, void* closure = null)
+    static extern(C) int _set_impl(int FieldIndex)
+                                  (PyObject* self_, PyObject* value, void* closure = null)
         nothrow
         in(self_ !is null)
     {

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -36,11 +36,14 @@ struct PythonType(T) {
     static if(is(T == struct)) {
         alias fieldNames = FieldNameTuple!T;
         alias fieldTypes = Fields!T;
-    } else static if(is(T == class) || is(T == interface)) {
+    } else static if(is(T == class)) {
         // recurse over base classes to get all fields
         alias fieldNames = AliasSeq!(FieldNameTuple!T, staticMap!(FieldNameTuple, BaseClassesTuple!T));
         private alias fieldType(string name) = typeof(__traits(getMember, T, name));
         alias fieldTypes = staticMap!(fieldType, fieldNames);
+    } else static if(is(T == interface)) {
+        alias fieldNames = AliasSeq!();
+        alias fieldTypes = AliasSeq!();
     }
 
     enum hasLength = is(typeof({ size_t len = T.init.length; }));

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -850,8 +850,14 @@ struct PythonClass(T) if(isUserAggregate!T) {
             return -1;
         }
 
-        if(!checkPythonType!(fieldTypes[FieldIndex])(value)) {
-            return -1;
+        static if(__traits(compiles, checkPythonType!(fieldTypes[FieldIndex])(value))) {
+            if(!checkPythonType!(fieldTypes[FieldIndex])(value)) {
+                return -1;
+            }
+        } else {
+            pragma(msg, "WARNING: cannot check python type for field #", FieldIndex, " of ", T);
+            // uncomment below to see compilation failure
+            // checkPythonType!(fieldTypes[FieldIndex])(value);
         }
 
         auto self = cast(PythonClass!T*) self_;

--- a/pynih/source/python/type.d
+++ b/pynih/source/python/type.d
@@ -376,8 +376,16 @@ struct PythonType(T) {
                         if(PyTuple_Size(args) != 0)
                             throw new Exception(T.stringof ~ " has no constructor therefore can't construct one from arguments");
                         return T.init;
-                    } else
-                        return T(fields);
+                    } else {
+                        static if(__traits(compiles, T(fields)))
+                            return T(fields);
+                        else {
+                            pragma(msg, "WARNING: cannot use implicit constructor for `", T, "`");
+                            // uncomment below to see the compiler error
+                            // auto _t_tmp = T(fields);
+                            return T.init;
+                        }
+                    }
                 }
 
                 return callDlangFunction!(typeof(impl), impl)(null /*self*/, args, kwargs);

--- a/tests/test_phobos.py
+++ b/tests/test_phobos.py
@@ -1,0 +1,2 @@
+def test_foo():
+    assert 1 == 2

--- a/tests/test_phobos.py
+++ b/tests/test_phobos.py
@@ -1,2 +1,2 @@
-def test_foo():
-    assert 1 == 2
+def test_protocol():
+    from phobos import Protocol


### PR DESCRIPTION
This PR doesn't successfully wrap std.socket. But it refactors pynih enough so that failures to wrap don't translate into compilation failures and then fails at actually importing anything from the generated shared library.

There are also many compile-time warnings about all of the types and functions that fail to wrap.