### PR TITLE
Bump pyd to v0.14.0 & add support for Python 3.8

### DIFF
--- a/examples/issues/dub.sdl
+++ b/examples/issues/dub.sdl
@@ -4,6 +4,13 @@ targetType "dynamicLibrary"
 dependency "vibe-d:redis" version="*"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/issues/dub.selections.json
+++ b/examples/issues/dub.selections.json
@@ -11,7 +11,7 @@
 		"mir-linux-kernel": "1.0.1",
 		"mirror": "0.3.0",
 		"openssl": "1.1.6+1.0.1g",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.16",

--- a/examples/numpy/dub.sdl
+++ b/examples/numpy/dub.sdl
@@ -2,6 +2,13 @@ name "numpy"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/numpy/dub.selections.json
+++ b/examples/numpy/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../"},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/create.d
+++ b/examples/phobos/create.d
@@ -31,6 +31,13 @@ void run(string[] args) @safe {
             targetType "dynamicLibrary"
 
 
+            configuration "python38" {
+                targetPath "lib/pyd"
+                lflags "-L$PYTHON_LIB_DIR"
+                dependency "autowrap:python" path="../../.."
+                subConfiguration "autowrap:python" "python38"
+            }
+
             configuration "python37" {
                 targetPath "lib/pyd"
                 lflags "-L$PYTHON_LIB_DIR"
@@ -79,7 +86,7 @@ void run(string[] args) @safe {
             	"versions": {
             		"autowrap": {"path":"../../.."},
             		"mirror": "0.3.0",
-            		"pyd": "0.13.1",
+            		"pyd": "0.14.0",
             		"unit-threaded": "1.0.4"
             	}
             }

--- a/examples/phobos/dub.sdl
+++ b/examples/phobos/dub.sdl
@@ -2,6 +2,13 @@ name "phobos"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/dub.selections.json
+++ b/examples/phobos/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../"},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_algorithm/dub.sdl
+++ b/examples/phobos/std_algorithm/dub.sdl
@@ -2,6 +2,13 @@ name "std_algorithm"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_algorithm/dub.selections.json
+++ b/examples/phobos/std_algorithm/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_array/dub.sdl
+++ b/examples/phobos/std_array/dub.sdl
@@ -2,6 +2,13 @@ name "std_array"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_array/dub.selections.json
+++ b/examples/phobos/std_array/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_ascii/dub.sdl
+++ b/examples/phobos/std_ascii/dub.sdl
@@ -2,6 +2,13 @@ name "std_ascii"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_ascii/dub.selections.json
+++ b/examples/phobos/std_ascii/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_base64/dub.sdl
+++ b/examples/phobos/std_base64/dub.sdl
@@ -2,6 +2,13 @@ name "std_base64"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_base64/dub.selections.json
+++ b/examples/phobos/std_base64/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_bigint/dub.sdl
+++ b/examples/phobos/std_bigint/dub.sdl
@@ -2,6 +2,13 @@ name "std_bigint"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_bigint/dub.selections.json
+++ b/examples/phobos/std_bigint/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_compiler/dub.sdl
+++ b/examples/phobos/std_compiler/dub.sdl
@@ -2,6 +2,13 @@ name "std_compiler"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_compiler/dub.selections.json
+++ b/examples/phobos/std_compiler/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_complex/dub.sdl
+++ b/examples/phobos/std_complex/dub.sdl
@@ -2,6 +2,13 @@ name "std_complex"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_complex/dub.selections.json
+++ b/examples/phobos/std_complex/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_container/dub.sdl
+++ b/examples/phobos/std_container/dub.sdl
@@ -2,6 +2,13 @@ name "std_container"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_container/dub.selections.json
+++ b/examples/phobos/std_container/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_conv/dub.sdl
+++ b/examples/phobos/std_conv/dub.sdl
@@ -2,6 +2,13 @@ name "std_conv"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_conv/dub.selections.json
+++ b/examples/phobos/std_conv/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_csv/dub.sdl
+++ b/examples/phobos/std_csv/dub.sdl
@@ -2,6 +2,13 @@ name "std_csv"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_csv/dub.selections.json
+++ b/examples/phobos/std_csv/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_datetime/dub.sdl
+++ b/examples/phobos/std_datetime/dub.sdl
@@ -2,6 +2,13 @@ name "std_datetime"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_datetime/dub.selections.json
+++ b/examples/phobos/std_datetime/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_demangle/dub.sdl
+++ b/examples/phobos/std_demangle/dub.sdl
@@ -2,6 +2,13 @@ name "std_demangle"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_demangle/dub.selections.json
+++ b/examples/phobos/std_demangle/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_digest/dub.sdl
+++ b/examples/phobos/std_digest/dub.sdl
@@ -2,6 +2,13 @@ name "std_digest"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_digest/dub.selections.json
+++ b/examples/phobos/std_digest/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_encoding/dub.sdl
+++ b/examples/phobos/std_encoding/dub.sdl
@@ -2,6 +2,13 @@ name "std_encoding"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_encoding/dub.selections.json
+++ b/examples/phobos/std_encoding/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_exception/dub.sdl
+++ b/examples/phobos/std_exception/dub.sdl
@@ -2,6 +2,13 @@ name "std_exception"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_exception/dub.selections.json
+++ b/examples/phobos/std_exception/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_experimental/dub.sdl
+++ b/examples/phobos/std_experimental/dub.sdl
@@ -2,6 +2,13 @@ name "std_experimental"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_experimental/dub.selections.json
+++ b/examples/phobos/std_experimental/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_file/dub.sdl
+++ b/examples/phobos/std_file/dub.sdl
@@ -2,6 +2,13 @@ name "std_file"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_file/dub.selections.json
+++ b/examples/phobos/std_file/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_format/dub.sdl
+++ b/examples/phobos/std_format/dub.sdl
@@ -2,6 +2,13 @@ name "std_format"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_format/dub.selections.json
+++ b/examples/phobos/std_format/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_functional/dub.sdl
+++ b/examples/phobos/std_functional/dub.sdl
@@ -2,6 +2,13 @@ name "std_functional"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_functional/dub.selections.json
+++ b/examples/phobos/std_functional/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_getopt/dub.sdl
+++ b/examples/phobos/std_getopt/dub.sdl
@@ -2,6 +2,13 @@ name "std_getopt"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_getopt/dub.selections.json
+++ b/examples/phobos/std_getopt/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_json/dub.sdl
+++ b/examples/phobos/std_json/dub.sdl
@@ -2,6 +2,13 @@ name "std_json"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_json/dub.selections.json
+++ b/examples/phobos/std_json/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_math/dub.sdl
+++ b/examples/phobos/std_math/dub.sdl
@@ -2,6 +2,13 @@ name "std_math"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_math/dub.selections.json
+++ b/examples/phobos/std_math/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_mathspecial/dub.sdl
+++ b/examples/phobos/std_mathspecial/dub.sdl
@@ -2,6 +2,13 @@ name "std_mathspecial"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_mathspecial/dub.selections.json
+++ b/examples/phobos/std_mathspecial/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_meta/dub.sdl
+++ b/examples/phobos/std_meta/dub.sdl
@@ -2,6 +2,13 @@ name "std_meta"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_meta/dub.selections.json
+++ b/examples/phobos/std_meta/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_mmfile/dub.sdl
+++ b/examples/phobos/std_mmfile/dub.sdl
@@ -1,6 +1,13 @@
 name "std_mmfile"
 targetType "dynamicLibrary"
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_mmfile/dub.selections.json
+++ b/examples/phobos/std_mmfile/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_net/dub.sdl
+++ b/examples/phobos/std_net/dub.sdl
@@ -2,6 +2,13 @@ name "std_net"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_net/dub.selections.json
+++ b/examples/phobos/std_net/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_numeric/dub.sdl
+++ b/examples/phobos/std_numeric/dub.sdl
@@ -2,6 +2,13 @@ name "std_numeric"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_numeric/dub.selections.json
+++ b/examples/phobos/std_numeric/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_outbuffer/dub.sdl
+++ b/examples/phobos/std_outbuffer/dub.sdl
@@ -2,6 +2,13 @@ name "std_outbuffer"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_outbuffer/dub.selections.json
+++ b/examples/phobos/std_outbuffer/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_path/dub.sdl
+++ b/examples/phobos/std_path/dub.sdl
@@ -2,6 +2,13 @@ name "std_path"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_path/dub.selections.json
+++ b/examples/phobos/std_path/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_process/dub.sdl
+++ b/examples/phobos/std_process/dub.sdl
@@ -2,6 +2,13 @@ name "std_process"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_process/dub.selections.json
+++ b/examples/phobos/std_process/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_random/dub.sdl
+++ b/examples/phobos/std_random/dub.sdl
@@ -2,6 +2,13 @@ name "std_random"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_random/dub.selections.json
+++ b/examples/phobos/std_random/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_range/dub.sdl
+++ b/examples/phobos/std_range/dub.sdl
@@ -2,6 +2,13 @@ name "std_range"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_range/dub.selections.json
+++ b/examples/phobos/std_range/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_regex/dub.sdl
+++ b/examples/phobos/std_regex/dub.sdl
@@ -2,6 +2,13 @@ name "std_regex"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_regex/dub.selections.json
+++ b/examples/phobos/std_regex/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_signals/dub.sdl
+++ b/examples/phobos/std_signals/dub.sdl
@@ -2,6 +2,13 @@ name "std_signals"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_signals/dub.selections.json
+++ b/examples/phobos/std_signals/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_socket/dub.sdl
+++ b/examples/phobos/std_socket/dub.sdl
@@ -2,6 +2,13 @@ name "std_socket"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_socket/dub.selections.json
+++ b/examples/phobos/std_socket/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_stdint/dub.sdl
+++ b/examples/phobos/std_stdint/dub.sdl
@@ -2,6 +2,13 @@ name "std_stdint"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_stdint/dub.selections.json
+++ b/examples/phobos/std_stdint/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_stdio/dub.sdl
+++ b/examples/phobos/std_stdio/dub.sdl
@@ -2,6 +2,13 @@ name "std_stdio"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_stdio/dub.selections.json
+++ b/examples/phobos/std_stdio/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_string/dub.sdl
+++ b/examples/phobos/std_string/dub.sdl
@@ -2,6 +2,13 @@ name "std_string"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_string/dub.selections.json
+++ b/examples/phobos/std_string/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_system/dub.sdl
+++ b/examples/phobos/std_system/dub.sdl
@@ -2,6 +2,13 @@ name "std_system"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_system/dub.selections.json
+++ b/examples/phobos/std_system/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_traits/dub.sdl
+++ b/examples/phobos/std_traits/dub.sdl
@@ -2,6 +2,13 @@ name "std_traits"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_traits/dub.selections.json
+++ b/examples/phobos/std_traits/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_typecons/dub.sdl
+++ b/examples/phobos/std_typecons/dub.sdl
@@ -2,6 +2,13 @@ name "std_typecons"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_typecons/dub.selections.json
+++ b/examples/phobos/std_typecons/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_typetuple/dub.sdl
+++ b/examples/phobos/std_typetuple/dub.sdl
@@ -2,6 +2,13 @@ name "std_typetuple"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_typetuple/dub.selections.json
+++ b/examples/phobos/std_typetuple/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_uni/dub.sdl
+++ b/examples/phobos/std_uni/dub.sdl
@@ -2,6 +2,13 @@ name "std_uni"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_uni/dub.selections.json
+++ b/examples/phobos/std_uni/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_uri/dub.sdl
+++ b/examples/phobos/std_uri/dub.sdl
@@ -2,6 +2,13 @@ name "std_uri"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_uri/dub.selections.json
+++ b/examples/phobos/std_uri/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_utf/dub.sdl
+++ b/examples/phobos/std_utf/dub.sdl
@@ -2,6 +2,13 @@ name "std_utf"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_utf/dub.selections.json
+++ b/examples/phobos/std_utf/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_uuid/dub.sdl
+++ b/examples/phobos/std_uuid/dub.sdl
@@ -2,6 +2,13 @@ name "std_uuid"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_uuid/dub.selections.json
+++ b/examples/phobos/std_uuid/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_variant/dub.sdl
+++ b/examples/phobos/std_variant/dub.sdl
@@ -2,6 +2,13 @@ name "std_variant"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_variant/dub.selections.json
+++ b/examples/phobos/std_variant/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_windows/dub.sdl
+++ b/examples/phobos/std_windows/dub.sdl
@@ -2,6 +2,13 @@ name "std_windows"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_windows/dub.selections.json
+++ b/examples/phobos/std_windows/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_xml/dub.selections.json
+++ b/examples/phobos/std_xml/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_zip/dub.sdl
+++ b/examples/phobos/std_zip/dub.sdl
@@ -2,6 +2,13 @@ name "std_zip"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_zip/dub.selections.json
+++ b/examples/phobos/std_zip/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/phobos/std_zlib/dub.sdl
+++ b/examples/phobos/std_zlib/dub.sdl
@@ -2,6 +2,13 @@ name "std_zlib"
 targetType "dynamicLibrary"
 
 
+configuration "python38" {
+    targetPath "lib/pyd"
+    lflags "-L$PYTHON_LIB_DIR"
+    dependency "autowrap:python" path="../../"
+    subConfiguration "autowrap:python" "python38"
+}
+
 configuration "python37" {
     targetPath "lib/pyd"
     lflags "-L$PYTHON_LIB_DIR"

--- a/examples/phobos/std_zlib/dub.selections.json
+++ b/examples/phobos/std_zlib/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../.."},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/pyd/dub.selections.json
+++ b/examples/pyd/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"autowrap": {"path":"../../"},
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/examples/simple/adder/dub.selections.json
+++ b/examples/simple/adder/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"simple": {"path":".."},
 		"test_allocator": "0.3.2",

--- a/examples/simple/api/dub.selections.json
+++ b/examples/simple/api/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"simple": {"path":".."},
 		"test_allocator": "0.3.2",

--- a/examples/simple/dub.selections.json
+++ b/examples/simple/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"test_allocator": "0.3.2",
 		"unit-threaded": "1.0.4"

--- a/examples/simple/prefix/dub.selections.json
+++ b/examples/simple/prefix/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"simple": {"path":".."},
 		"test_allocator": "0.3.2",

--- a/examples/simple/structs/dub.selections.json
+++ b/examples/simple/structs/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"simple": {"path":".."},
 		"test_allocator": "0.3.2",

--- a/examples/simple/wrap_all/dub.selections.json
+++ b/examples/simple/wrap_all/dub.selections.json
@@ -7,7 +7,7 @@
 		"localimport": "1.3.0",
 		"mirror": "0.3.0",
 		"nogc": "0.5.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"scriptlike": "0.10.3",
 		"simple": {"path":".."},
 		"test_allocator": "0.3.2",

--- a/pyd/dub.sdl
+++ b/pyd/dub.sdl
@@ -3,13 +3,17 @@ description "Wrap existing D code for use in python using pyd"
 authors "Atila Neves"
 license "BSD"
 targetType "library"
-dependency "pyd" version="~>0.13.0"
+dependency "pyd" version="~>0.14.0"
 dependency "autowrap:common" path="../common"
 dependency "autowrap:reflection" path="../reflection"
 versions "PydPythonExtension"
 
 configuration "env" {
     subConfiguration "pyd" "env"
+}
+
+configuration "python38" {
+    subConfiguration "pyd" "python38"
 }
 
 configuration "python37" {

--- a/pyd/dub.selections.json
+++ b/pyd/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"mirror": "0.3.0",
-		"pyd": "0.13.1",
+		"pyd": "0.14.0",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/pyd/source/autowrap/python/pyd/class_wrap.d
+++ b/pyd/source/autowrap/python/pyd/class_wrap.d
@@ -39,7 +39,7 @@ private template MemberFunctionImpl(alias _fn, string name, fn_t, string docstri
     import pyd.references: PydTypeObject;
     import pyd.def: def_selector;
     import pyd.func_wrap: minArgs, method_wrap;
-    import util.typeinfo: ApplyConstness, constness;
+    import pyd.util.typeinfo: ApplyConstness, constness;
     import deimos.python.methodobject: PyMethodDef, PyCFunction, METH_VARARGS, METH_KEYWORDS;
 
     alias func = def_selector!(_fn, fn_t).FN;
@@ -67,7 +67,7 @@ private template MemberFunctionImpl(alias _fn, string name, fn_t, string docstri
     }
 
     template shim(size_t i, T) {
-        import util.replace: Replace;
+        import pyd.util.replace: Replace;
         import std.traits: functionAttributes, variadicFunctionStyle, Variadic;
 
         enum shim = Replace!(q{

--- a/python/dub.sdl
+++ b/python/dub.sdl
@@ -11,6 +11,10 @@ configuration "env" {
     subConfiguration "autowrap:pyd" "env"
 }
 
+configuration "python38" {
+    subConfiguration "autowrap:pyd" "python38"
+}
+
 configuration "python37" {
     subConfiguration "autowrap:pyd" "python37"
 }


### PR DESCRIPTION
pyd v0.14 came with a breaking API change, moving the `util` package to `pyd.util`.