### PR TITLE
update mirror to 0.3.1, pyd to 0.14.3; add configuration python3.9

### DIFF
--- a/csharp/tests/dub.selections.json
+++ b/csharp/tests/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"autowrap": {"path":"../../"},
-		"mirror": "0.3.0",
+		"mirror": "0.3.1",
 		"scriptlike": "0.10.3",
 		"unit-threaded": "1.0.4"
 	}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mirror": "0.3.0",
-		"unit-threaded": "1.0.4"
+		"mirror": "0.3.1",
+		"unit-threaded": "2.0.4"
 	}
 }

--- a/pyd/dub.sdl
+++ b/pyd/dub.sdl
@@ -3,13 +3,17 @@ description "Wrap existing D code for use in python using pyd"
 authors "Atila Neves"
 license "BSD"
 targetType "library"
-dependency "pyd" version="~>0.14.0"
+dependency "pyd" version="~>0.14.3"
 dependency "autowrap:common" path="../common"
 dependency "autowrap:reflection" path="../reflection"
 versions "PydPythonExtension"
 
 configuration "env" {
     subConfiguration "pyd" "env"
+}
+
+configuration "python39" {
+    subConfiguration "pyd" "python39"
 }
 
 configuration "python38" {

--- a/pyd/dub.selections.json
+++ b/pyd/dub.selections.json
@@ -1,8 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mirror": "0.3.0",
-		"pyd": "0.14.1",
+		"mirror": "0.3.1",
+		"pyd": "0.14.3",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/pynih/contract/dub.selections.json
+++ b/pynih/contract/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"autowrap": {"path":"../.."},
-		"mirror": "0.3.0",
+		"mirror": "0.3.1",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/pynih/dub.sdl
+++ b/pynih/dub.sdl
@@ -5,7 +5,7 @@ targetType "library"
 
 dependency "autowrap:common" path="../common"
 dependency "autowrap:reflection" path="../reflection"
-dependency "mirror" version="~>0.3.0"
+dependency "mirror" version="~>0.3.1"
 
 preGenerateCommands "make -C $PACKAGE_DIR source/python/raw.d" platform="posix"
 

--- a/pynih/dub.selections.json
+++ b/pynih/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mirror": "0.3.0",
+		"mirror": "0.3.1",
 		"unit-threaded": "1.0.4"
 	}
 }

--- a/python/dub.sdl
+++ b/python/dub.sdl
@@ -11,6 +11,10 @@ configuration "env" {
     subConfiguration "autowrap:pyd" "env"
 }
 
+configuration "python39" {
+    subConfiguration "autowrap:pyd" "python39"
+}
+
 configuration "python38" {
     subConfiguration "autowrap:pyd" "python38"
 }

--- a/reflection/dub.sdl
+++ b/reflection/dub.sdl
@@ -5,4 +5,4 @@ license "BSD"
 targetType "library"
 
 dependency "autowrap:common" path="../common"
-dependency "mirror" version="~>0.3.0"
+dependency "mirror" version="~>0.3.1"


### PR DESCRIPTION
Since pyd has python3.9 already:

https://github.com/ariovistus/pyd/commit/63de090d705b39624aa3d735105e4d14e251911e

And I've tested on my local machine autowrap with python3.9, and it's working.

Thanks.