### PR TITLE
POC: Importc pynih

### DIFF
--- a/pynih/.gitignore
+++ b/pynih/.gitignore
@@ -1,9 +1,12 @@
 *.o
 *.so
 *.dynlib
+*.dylib
 *.dll
 *.lib
 *.exp
 __pycache__
 *.pyc
 *.d.tmp
+generated/
+pynih-test-library

--- a/pynih/Makefile
+++ b/pynih/Makefile
@@ -1,5 +1,12 @@
 DC ?= dmd
-dpp_version = 0.4.13
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	shared_ext := .so
+endif
+ifeq ($(UNAME_S),Darwin)
+	shared_ext := .dylib
+endif
 
 PYTHON_INCLUDE_DIR = $(shell python -c 'from distutils.sysconfig import get_python_inc; print(get_python_inc())')
 
@@ -7,10 +14,20 @@ PYTHON_INCLUDE_DIR = $(shell python -c 'from distutils.sysconfig import get_pyth
 test: contract/contract.so
 	PYTHONPATH=$(shell pwd)/contract pytest -s -vv contract/tests
 
-contract/contract.so: contract/libcontract.so
+contract/contract.so: contract/libcontract$(shared_ext)
 	cp $< $@
 
 
-.PHONY: test contract/libcontract.so
-contract/libcontract.so:
-	cd contract && dub build -q --compiler=${DC}
+.PHONY: test contract/libcontract$(shared_ext)
+contract/libcontract$(shared_ext):
+	cd contract && dub build -v --compiler=${DC}
+
+preprocess: generated/python/impl.i
+
+generated/python/impl.i: source/python/_impl.c
+	mkdir -p $(@D)
+	clang -include /Users/john/dlang/ldc-1.32.0/import/importc.h -fno-blocks -std=c11 -I /opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/include/python3.11 -E source/python/_impl.c -o - | ./postpreprocess.d > generated/python/impl.i
+
+.PHONY: clean
+clean:
+	rm -rf generated

--- a/pynih/Makefile
+++ b/pynih/Makefile
@@ -1,4 +1,8 @@
-DC ?= dmd
+DC ?= $(shell echo $$DC)
+PYTHON ?= python
+IMPORTC_H_PATH ?= $(shell echo $$IMPORTC_H_PATH)
+
+SHELL=/bin/bash -o pipefail
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -8,7 +12,7 @@ ifeq ($(UNAME_S),Darwin)
 	shared_ext := .dylib
 endif
 
-PYTHON_INCLUDE_DIR = $(shell python -c 'from distutils.sysconfig import get_python_inc; print(get_python_inc())')
+PYTHON_INCLUDE_DIR = $(shell $(PYTHON) -c 'from distutils.sysconfig import get_python_inc; print(get_python_inc())')
 
 .PHONY: test
 test: contract/contract.so
@@ -17,17 +21,16 @@ test: contract/contract.so
 contract/contract.so: contract/libcontract$(shared_ext)
 	cp $< $@
 
-
 .PHONY: test contract/libcontract$(shared_ext)
 contract/libcontract$(shared_ext):
-	cd contract && dub build -v --compiler=${DC}
+	cd contract && dub build -q --compiler=${DC}
 
 preprocess: generated/python/impl.i
 
 generated/python/impl.i: source/python/_impl.c
 	mkdir -p $(@D)
-	clang -include /Users/john/dlang/ldc-1.32.0/import/importc.h -fno-blocks -std=c11 -I /opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/include/python3.11 -E source/python/_impl.c -o - | ./postpreprocess.d > generated/python/impl.i
+	clang -include $(IMPORTC_H_PATH) -fno-blocks -std=c11 -I $(PYTHON_INCLUDE_DIR) -E source/python/_impl.c -o - | ./postpreprocess.d > generated/python/impl.i
 
 .PHONY: clean
 clean:
-	rm -rf generated
+	rm -rf generated contract/contract.so contract/libcontract$(shared_ext)

--- a/pynih/README.md
+++ b/pynih/README.md
@@ -1,0 +1,2 @@
+Example usage:
+

--- a/pynih/contract/source/contract/scalars.d
+++ b/pynih/contract/source/contract/scalars.d
@@ -44,7 +44,7 @@ package PyObject* one_bool_param_to_not(PyObject* self, PyObject *args) nothrow 
 
 
 // returns the number passed in multiplied by two
-package PyObject* one_int_param_to_times_two(PyObject* self, PyObject *args) /*nothrow @nogc*/ {
+package PyObject* one_int_param_to_times_two(PyObject* self, PyObject *args) nothrow @nogc {
 
     long arg;
 

--- a/pynih/contract/source/contract/scalars.d
+++ b/pynih/contract/source/contract/scalars.d
@@ -37,14 +37,14 @@ package PyObject* one_bool_param_to_not(PyObject* self, PyObject *args) nothrow 
     if(arg is null) return null;
 
     if(!PyBool_Check(arg)) return null;
-    const dArg = arg == pyTrue;
+    const dArg = arg == Py_True;
 
     return PyBool_FromLong(!dArg);
 }
 
 
 // returns the number passed in multiplied by two
-package PyObject* one_int_param_to_times_two(PyObject* self, PyObject *args) nothrow @nogc {
+package PyObject* one_int_param_to_times_two(PyObject* self, PyObject *args) /*nothrow @nogc*/ {
 
     long arg;
 
@@ -120,7 +120,7 @@ package PyObject* one_string_param_to_string(PyObject* self, PyObject *args) not
 // appends "_suffix" to the string passed in without using the GC
 package PyObject* one_string_param_to_string_manual_mem(PyObject* self, PyObject *args) nothrow @nogc {
     import std.string: fromStringz;
-    import core.stdc.stdlib: malloc;
+    import core.stdc.stdlib: malloc, free;
     import core.stdc.string: strlen;
 
     if(PyTuple_Size(args) != 1) {

--- a/pynih/contract/source/contract/udt.d
+++ b/pynih/contract/source/contract/udt.d
@@ -34,7 +34,7 @@ package PyObject* simple_struct_func(PyObject* self, PyObject *args) nothrow @no
         type.tp_name = &"MyType"[0];
         type.tp_basicsize = MyType.sizeof;
         type.tp_members = &members[0];
-        type.tp_flags = TypeFlags.Default;
+        type.tp_flags = Py_TPFLAGS_DEFAULT;
 
         if(PyType_Ready(&type) < 0) {
             PyErr_SetString(PyExc_TypeError, &"not ready"[0]);
@@ -87,7 +87,7 @@ package PyObject* twice_struct_func(PyObject* self, PyObject *args) nothrow @nog
         type.tp_name = &"Twice"[0];
         type.tp_basicsize = Twice.sizeof;
         type.tp_methods = &methods[0];
-        type.tp_flags = TypeFlags.Default;
+        type.tp_flags = Py_TPFLAGS_DEFAULT;
 
         if(PyType_Ready(&type) < 0) {
             PyErr_SetString(PyExc_TypeError, &"not ready"[0]);
@@ -224,7 +224,7 @@ package PyObject* struct_getset(PyObject* self, PyObject *args) nothrow @nogc {
 
         outerType.tp_name = &"StructGetSet"[0];
         outerType.tp_basicsize = StructGetSet.sizeof;
-        outerType.tp_flags = TypeFlags.Default;
+        outerType.tp_flags = Py_TPFLAGS_DEFAULT;
         outerType.tp_repr = outerType.tp_str = &reprOuter;
         outerType.tp_getset = &outerGetSets[0];
 
@@ -242,7 +242,7 @@ package PyObject* struct_getset(PyObject* self, PyObject *args) nothrow @nogc {
 
         innerType.tp_name = &"StructGetSet.Inner"[0];
         innerType.tp_basicsize = StructGetSet.Inner.sizeof;
-        innerType.tp_flags = TypeFlags.Default;
+        innerType.tp_flags = Py_TPFLAGS_DEFAULT;
         innerType.tp_repr = innerType.tp_str = &reprInner;
         innerType.tp_getset = &innerGetSets[0];
 

--- a/pynih/dub.sdl
+++ b/pynih/dub.sdl
@@ -6,8 +6,9 @@ targetType "library"
 dependency "autowrap:common" path=".."
 dependency "autowrap:reflection" path=".."
 dependency "mirror" version="~>0.3.0"
-dependency "monty" version="~>0.0.1"
 
-configuration "default" {
+preGenerateCommands "make preprocess"
+importPaths "source" "generated/python"
+sourceFiles "generated/python/impl.i"
 
-}
+libs "python3.11"

--- a/pynih/dub.sdl
+++ b/pynih/dub.sdl
@@ -7,7 +7,7 @@ dependency "autowrap:common" path=".."
 dependency "autowrap:reflection" path=".."
 dependency "mirror" version="~>0.3.0"
 
-preGenerateCommands "make preprocess"
+preGenerateCommands "make preprocess DC=$DC IMPORTC_H_PATH=$IMPORTC_H_PATH"
 importPaths "source" "generated/python"
 sourceFiles "generated/python/impl.i"
 

--- a/pynih/dub.selections.json
+++ b/pynih/dub.selections.json
@@ -1,7 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"mirror": "0.3.2",
-		"unit-threaded": "1.0.4"
+		"autowrap": {"path":".."},
+		"mirror": "0.3.3",
+		"unit-threaded": "2.1.5"
 	}
 }

--- a/pynih/postpreprocess.d
+++ b/pynih/postpreprocess.d
@@ -1,0 +1,28 @@
+#!/usr/bin/env rdmd
+
+/// Remove system libraries from the preprocessed output
+
+import std.stdio;
+import std.string;
+import std.array;
+import std.algorithm;
+
+void main() {
+    bool skip = false;
+    foreach (line; stdin.byLine()) {
+        line = chomp(line);
+
+        if (!skip)
+            writeln(line);
+
+        if (line.startsWith("# "))
+        {
+            auto toks = line.strip().split(" ");
+            auto linenum = toks[1];
+            auto filename = toks[2];
+            auto flags = toks[3 .. $];
+
+            skip = flags.canFind("3");
+        }
+    }
+}

--- a/pynih/source/autowrap/pynih/python/conv/d_to_python.d
+++ b/pynih/source/autowrap/pynih/python/conv/d_to_python.d
@@ -18,8 +18,9 @@ PyObject* toPython(in bool val) @trusted @nogc {
     auto pyTrue = cast(PyObject*) &_Py_TrueStruct;
     auto pyFalse = cast(PyObject*) &_Py_FalseStruct;
 
-    static PyObject* incAndRet(PyObject* obj) {
-        Py_IncRef(obj);
+    static PyObject* incAndRet(PyObject* obj) @nogc {
+        
+        (cast(int function(PyObject*) @nogc)(&Py_IncRef))(obj);
         return obj;
     }
 

--- a/pynih/source/autowrap/pynih/python/cooked.d
+++ b/pynih/source/autowrap/pynih/python/cooked.d
@@ -64,7 +64,9 @@ private PyMethodDef* cFunctionsToPyMethodDefs(alias cfunctions)()
         alias cfunction = function_.symbol;
         static assert(is(typeof(&cfunction): PyCFunction) ||
                       is(typeof(&cfunction): PyCFunctionWithKeywords),
-                      __traits(identifier, cfunction) ~ " is not a Python C function");
+                      __traits(identifier, cfunction) ~ " is not a Python C function, has type\n"
+                        ~ typeof(cfunction).stringof ~ " which isn't either\n"
+                        ~ PyCFunction.stringof ~ " or\n" ~ PyCFunctionWithKeywords.stringof);
 
         methods[i] = pyMethodDef!(function_.identifier)(cast(PyCFunction) &cfunction);
     }}

--- a/pynih/source/autowrap/pynih/python/type.d
+++ b/pynih/source/autowrap/pynih/python/type.d
@@ -241,8 +241,8 @@ struct PythonType(T) {
             _pyType.tp_as_sequence.sq_length = &_py_length;
         }
 
-        if(PyType_Ready_nothrow(&_pyType) < 0) {
-            PyErr_SetString_nothrow(PyExc_TypeError, &"not ready"[0]);
+        if(PyType_Ready(&_pyType) < 0) {
+            PyErr_SetString(PyExc_TypeError, &"not ready"[0]);
             failedToReady = true;
         }
     }
@@ -670,10 +670,6 @@ struct PythonFunction(alias F) {
     }
 }
 
-//import python.c : withAttr;
-alias PyErr_SetString_nothrow = PyErr_SetString; //withAttr!(PyErr_SetString, FunctionAttribute.nothrow_);
-alias PyType_Ready_nothrow = PyType_Ready; //withAttr!(PyType_Ready, FunctionAttribute.nothrow_);
-
 auto noThrowable(alias F, A...)(auto ref A args) nothrow {
     import python.c: PyErr_SetString, PyExc_RuntimeError;
     import std.string: toStringz;
@@ -682,14 +678,14 @@ auto noThrowable(alias F, A...)(auto ref A args) nothrow {
     try {
         return F(args);
     } catch(Exception e) {
-        PyErr_SetString_nothrow(PyExc_RuntimeError, e.msg.toStringz);
+        PyErr_SetString(PyExc_RuntimeError, e.msg.toStringz);
         return ReturnType!F.init;
     } catch(Error e) {
         import std.conv: text;
         try
-            PyErr_SetString_nothrow(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.text).toStringz);
+            PyErr_SetString(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.text).toStringz);
         catch(Exception _)
-            PyErr_SetString_nothrow(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.msg).toStringz);
+            PyErr_SetString(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.msg).toStringz);
 
         return ReturnType!F.init;
     }
@@ -986,7 +982,7 @@ struct PythonClass(T) {//}if(isUserAggregate!T) {
 
         if(value is null) {
             enum deleteErrStr = "Cannot delete " ~ fieldNames[FieldIndex];
-            PyErr_SetString_nothrow(PyExc_TypeError, deleteErrStr.toStringz);
+            PyErr_SetString(PyExc_TypeError, deleteErrStr.toStringz);
             return -1;
         }
 

--- a/pynih/source/autowrap/pynih/python/type.d
+++ b/pynih/source/autowrap/pynih/python/type.d
@@ -4,10 +4,10 @@
 module autowrap.pynih.python.type;
 
 
-import python.c: PyObject;
+import python.c: PyObject, PyErr_SetString, PyType_Ready;
 import mirror.meta.traits: isParameter, BinaryOperator;
 import std.traits: Unqual, isArray, isIntegral, isBoolean, isFloatingPoint,
-    isAggregateType, isCallable, isAssociativeArray, isSomeFunction;
+    isAggregateType, isCallable, isAssociativeArray, isSomeFunction, FunctionAttribute;
 import std.datetime: DateTime, Date, TimeOfDay;
 import std.typecons: Tuple;
 import std.range.primitives: isInputRange;
@@ -63,9 +63,9 @@ struct PythonType(T) {
 
     private static void initialise() nothrow {
         import autowrap.common: AlwaysTry;
-        import python.c: PyType_GenericNew, PyType_Ready, TypeFlags,
+        import python.c: PyType_GenericNew,
             PyErr_SetString, PyExc_TypeError,
-            PyNumberMethods, PySequenceMethods;
+            PyNumberMethods, PySequenceMethods, Py_TPFLAGS_DEFAULT;
         import mirror.meta.traits: UnaryOperators, BinaryOperators, AssignOperators, functionName;
         import std.traits: arity, hasMember, TemplateOf;
         import std.meta: Filter;
@@ -76,7 +76,7 @@ struct PythonType(T) {
         // This allows tp_name to do its usual Python job and allows us to
         // construct a D class from its runtime Python type.
         _pyType.tp_name = fullyQualifiedName!(Unqual!T).ptr;
-        _pyType.tp_flags = TypeFlags.Default;
+        _pyType.tp_flags = Py_TPFLAGS_DEFAULT;
         static if(is(T == class) || is(T == interface))
             _pyType.tp_flags |= TypeFlags.BaseType;
 
@@ -241,8 +241,8 @@ struct PythonType(T) {
             _pyType.tp_as_sequence.sq_length = &_py_length;
         }
 
-        if(PyType_Ready(&_pyType) < 0) {
-            PyErr_SetString(PyExc_TypeError, &"not ready"[0]);
+        if(PyType_Ready_nothrow(&_pyType) < 0) {
+            PyErr_SetString_nothrow(PyExc_TypeError, &"not ready"[0]);
             failedToReady = true;
         }
     }
@@ -670,23 +670,26 @@ struct PythonFunction(alias F) {
     }
 }
 
+//import python.c : withAttr;
+alias PyErr_SetString_nothrow = PyErr_SetString; //withAttr!(PyErr_SetString, FunctionAttribute.nothrow_);
+alias PyType_Ready_nothrow = PyType_Ready; //withAttr!(PyType_Ready, FunctionAttribute.nothrow_);
 
-auto noThrowable(alias F, A...)(auto ref A args) {
+auto noThrowable(alias F, A...)(auto ref A args) nothrow {
     import python.c: PyErr_SetString, PyExc_RuntimeError;
     import std.string: toStringz;
-    import std.traits: ReturnType;
+    import std.traits: ReturnType, FunctionAttribute;
 
     try {
         return F(args);
     } catch(Exception e) {
-        PyErr_SetString(PyExc_RuntimeError, e.msg.toStringz);
+        PyErr_SetString_nothrow(PyExc_RuntimeError, e.msg.toStringz);
         return ReturnType!F.init;
     } catch(Error e) {
         import std.conv: text;
         try
-            PyErr_SetString(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.text).toStringz);
+            PyErr_SetString_nothrow(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.text).toStringz);
         catch(Exception _)
-            PyErr_SetString(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.msg).toStringz);
+            PyErr_SetString_nothrow(PyExc_RuntimeError, ("FATAL ERROR: " ~ e.msg).toStringz);
 
         return ReturnType!F.init;
     }
@@ -978,11 +981,12 @@ struct PythonClass(T) {//}if(isUserAggregate!T) {
         nothrow
         in(self_ !is null)
     {
-        import python.c: Py_IncRef, Py_DecRef, PyErr_SetString, PyExc_TypeError;
+        import python.c: Py_IncRef, Py_DecRef, PyExc_TypeError;
+        import std.string: toStringz;
 
         if(value is null) {
             enum deleteErrStr = "Cannot delete " ~ fieldNames[FieldIndex];
-            PyErr_SetString(PyExc_TypeError, deleteErrStr);
+            PyErr_SetString_nothrow(PyExc_TypeError, deleteErrStr.toStringz);
             return -1;
         }
 

--- a/pynih/source/autowrap/pynih/wrap.d
+++ b/pynih/source/autowrap/pynih/wrap.d
@@ -15,11 +15,6 @@ import mirror.meta.reflection : FunctionSymbol;
 import std.meta: allSatisfy;
 import std.traits: isInstanceOf, isSomeFunction;
 
-// This is required to avoid linker errors. Before it was in the string mixin,
-// but there's no need for it there, instead we declare it here in the library
-// instead.
-export __gshared extern(C) PyDateTime_CAPI* PyDateTimeAPI;
-
 
 /**
    Returns a string to mixin that implements the necessary boilerplate

--- a/pynih/source/python/_impl.c
+++ b/pynih/source/python/_impl.c
@@ -1,0 +1,78 @@
+__import core.stdc.stdlib;
+__import core.stdc.stdint;
+__import core.stdc.stdio;
+__import core.stdc.time;
+__import core.stdc.assert_;
+__import core.sys.posix.pthread;
+
+ // can't use these because then importC chokes on uses of them in C casts (or maybe sizeof ??)
+//__import object : size_t, ptrdiff_t;
+
+// TODO: not so portable...
+#define size_t unsigned long
+#define ssize_t long
+
+#include "Python.h"
+#include "datetime.h"
+#include "structmember.h"
+
+#define macroToFunc(returnT, name, p1T) returnT (name)(p1T p1) { return name(p1); }
+#define macroToFunc2(returnT, name, p1T, p2T) returnT (name)(p1T p1, p2T p2) { return name(p1, p2); }
+#define macroToFunc3(returnT, name, p1T, p2T, p3T) returnT (name)(p1T p1, p2T p2, p3T p3) { return name(p1, p2, p3); }
+#define macroToFunc4(returnT, name, p1T, p2T, p3T, p4T) returnT (name)(p1T p1, p2T p2, p3T p3, p4T p4)\
+                                                        { return name(p1, p2, p3, p4); }
+#define macroToFunc5(returnT, name, p1T, p2T, p3T, p4T, p5T) returnT (name)(p1T p1, p2T p2, p3T p3, p4T p4, p5T p5) \
+                                                        { return name(p1, p2, p3, p4, p5); }
+#define macroToFunc6(returnT, name, p1T, p2T, p3T, p4T, p5T, p6T) returnT (name)(p1T p1, p2T p2, p3T p3, p4T p4, p5T p5, p6T p6) \
+                                                        { return name(p1, p2, p3, p4, p5, p6); }
+#define macroToFunc7(returnT, name, p1T, p2T, p3T, p4T, p5T, p6T, p7T) returnT (name)(p1T p1, p2T p2, p3T p3, p4T p4, p5T p5, p6T p6, p7T p7) \
+                                                        { return name(p1, p2, p3, p4, p5, p6, p7); }
+
+macroToFunc(int, PyList_Check, PyObject *)
+macroToFunc(int, PyTuple_Check, PyObject *)
+macroToFunc(int, PyTime_Check, PyObject *)
+macroToFunc(int, PyUnicode_Check, PyObject *)
+macroToFunc(int, PyDict_Check, PyObject *)
+macroToFunc(int, PyBool_Check, PyObject *)
+macroToFunc(PyObject *, PyModule_Create, PyModuleDef *)
+
+// just using pyobject because these aren't supposed to be type checked, see python docs
+macroToFunc(int, PyDateTime_GET_YEAR, PyObject *)
+macroToFunc(int, PyDateTime_GET_MONTH, PyObject *)
+macroToFunc(int, PyDateTime_GET_DAY, PyObject *)
+macroToFunc(int, PyDateTime_DATE_GET_HOUR, PyObject *)
+macroToFunc(int, PyDateTime_DATE_GET_MINUTE, PyObject *)
+macroToFunc(int, PyDateTime_DATE_GET_SECOND, PyObject *)
+
+macroToFunc3(PyObject *, PyDate_FromDate, int, int, int)
+
+macroToFunc7(PyObject *, PyDateTime_FromDateAndTime, int, int, int, int, int, int, int)
+
+#define DefineToConstGlobal(T, NAME) const T NAME##_ = NAME;
+
+DefineToConstGlobal(int, METH_VARARGS)
+DefineToConstGlobal(int, METH_KEYWORDS)
+DefineToConstGlobal(int, METH_STATIC)
+DefineToConstGlobal(int, Py_LT)
+DefineToConstGlobal(int, Py_EQ)
+DefineToConstGlobal(int, Py_GT)
+DefineToConstGlobal(int, Py_LE)
+DefineToConstGlobal(int, Py_NE)
+DefineToConstGlobal(int, Py_GE)
+DefineToConstGlobal(int, Py_TPFLAGS_DEFAULT) // ? on type
+DefineToConstGlobal(PyObject *, Py_None)
+DefineToConstGlobal(PyObject *, Py_True)
+DefineToConstGlobal(PyObject *, Py_False)
+DefineToConstGlobal(int, T_INT)
+DefineToConstGlobal(int, T_DOUBLE)
+
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+// checks on the D side to make sure the code we're using isn't out of date
+const char* PyObject_HEAD_code = xstr(PyObject_HEAD);
+
+void pyDateTimeImport(void) {
+    PyDateTimeAPI = (PyDateTime_CAPI *)PyCapsule_Import(PyDateTime_CAPSULE_NAME, 0);
+}

--- a/pynih/source/python/c.d
+++ b/pynih/source/python/c.d
@@ -1,0 +1,95 @@
+module python.c;
+
+static import impl = impl;
+
+import std.traits : FunctionAttribute;
+
+template withAttr(alias f, FunctionAttribute attributes, string name) {
+    import std.traits :  SetFunctionAttributes, functionAttributes, functionLinkage,
+        ReturnType, Parameters, variadicFunctionStyle, Variadic;
+
+    //pragma(msg, __LINE__, ": ", "not a type ", __traits(identifier, f), " ", typeof(f));
+
+    enum newAttributes = functionAttributes!f | attributes;
+    auto getFptr() {
+        static if (is(typeof(*f) == function)) {
+            return f;
+        } else {
+            return &f;
+        }
+    }
+    alias fptrT = typeof(getFptr());
+    alias newFptrT = SetFunctionAttributes!(fptrT, functionLinkage!f, newAttributes);
+
+    static if (variadicFunctionStyle!newFptrT == Variadic.c) {
+        auto withAttr(Args ...)(Parameters!newFptrT args, Args extraArgs) {
+            return (cast(newFptrT) getFptr())(args, extraArgs);
+        }
+    } else {
+        auto withAttr(Parameters!newFptrT args) {
+            return (cast(newFptrT) getFptr())(args);
+        }
+    }
+}
+
+// don't do anything to types
+template withAttr(f, FunctionAttribute attributes, string name) {
+    //pragma(msg, __LINE__, ": ", "it's a type ", f);
+    alias withAttr = f;
+}
+
+template maybeAddAttributes(alias s, string name) {
+    import std.traits : FunctionAttribute, isCallable;
+    static if (is(typeof(s) == function) || is(typeof(*s) == function)) {
+        //pragma(msg, __LINE__, ": ", "it's a function ");
+        alias maybeAddAttributes = withAttr!(s, FunctionAttribute.nothrow_ | FunctionAttribute.nogc, name);
+    } else {
+        alias maybeAddAttributes = s;
+    }
+}
+
+enum ignore = ["PySignal_SetWakeupFd", "_PyCodec_Forget"];
+
+static foreach (mem; __traits(allMembers, impl)) {
+    //pragma(msg, "\n", __LINE__, ": ", mem);
+    static foreach (toIgnore; ignore) {
+        static if (mem == toIgnore) {
+            mixin(`enum noWrap` ~ mem ~ `;`);
+        }
+    }
+    static if (!is(mixin(`noWrap` ~ mem))) {
+        mixin(`alias ` ~ mem ~ ` = maybeAddAttributes!(__traits(getMember, impl, mem), mem);`);
+    }
+    //pragma(msg, __LINE__, ": ", mixin(mem));
+}
+
+//public import impl;
+
+string untranslate(string name) {
+    return `auto ` ~ name ~ ` = ` ~ name ~ `_;`;
+}
+
+static foreach (name; ["METH_VARARGS", "METH_KEYWORDS", "METH_STATIC",
+    "Py_LT", "Py_EQ", "Py_GT", "Py_LE", "Py_NE", "Py_GE", "Py_TPFLAGS_DEFAULT",
+    "T_INT", "T_DOUBLE"]) {
+    mixin(untranslate(name));
+}
+
+static foreach(name; ["Py_None", "Py_True", "Py_False"]) {
+    mixin(`PyObject* ` ~ name ~ `;`);
+    shared static this() {
+        mixin(name ~ ` = ` ~ name ~ `_;`);
+    }
+}
+
+mixin template PyObjectHead() {
+    import impl : PyObject_HEAD_code;
+    shared static this() {
+        assert(PyObject_HEAD_code == "PyObject ob_base;", "Error, PyObject_HEAD changed");
+    }
+    PyObject ob_base;
+}
+
+auto pyObjectNew(T)(PyTypeObject* typeobj) {
+    return cast(T*) _PyObject_New(typeobj);
+}

--- a/pynih/source/python/c.d
+++ b/pynih/source/python/c.d
@@ -1,14 +1,12 @@
 module python.c;
 
-static import impl = impl;
+static import impl;
 
 import std.traits : FunctionAttribute;
 
 template withAttr(alias f, FunctionAttribute attributes, string name) {
     import std.traits :  SetFunctionAttributes, functionAttributes, functionLinkage,
         ReturnType, Parameters, variadicFunctionStyle, Variadic;
-
-    //pragma(msg, __LINE__, ": ", "not a type ", __traits(identifier, f), " ", typeof(f));
 
     enum newAttributes = functionAttributes!f | attributes;
     auto getFptr() {
@@ -34,14 +32,12 @@ template withAttr(alias f, FunctionAttribute attributes, string name) {
 
 // don't do anything to types
 template withAttr(f, FunctionAttribute attributes, string name) {
-    //pragma(msg, __LINE__, ": ", "it's a type ", f);
     alias withAttr = f;
 }
 
 template maybeAddAttributes(alias s, string name) {
     import std.traits : FunctionAttribute, isCallable;
     static if (is(typeof(s) == function) || is(typeof(*s) == function)) {
-        //pragma(msg, __LINE__, ": ", "it's a function ");
         alias maybeAddAttributes = withAttr!(s, FunctionAttribute.nothrow_ | FunctionAttribute.nogc, name);
     } else {
         alias maybeAddAttributes = s;
@@ -51,7 +47,6 @@ template maybeAddAttributes(alias s, string name) {
 enum ignore = ["PySignal_SetWakeupFd", "_PyCodec_Forget"];
 
 static foreach (mem; __traits(allMembers, impl)) {
-    //pragma(msg, "\n", __LINE__, ": ", mem);
     static foreach (toIgnore; ignore) {
         static if (mem == toIgnore) {
             mixin(`enum noWrap` ~ mem ~ `;`);
@@ -60,13 +55,10 @@ static foreach (mem; __traits(allMembers, impl)) {
     static if (!is(mixin(`noWrap` ~ mem))) {
         mixin(`alias ` ~ mem ~ ` = maybeAddAttributes!(__traits(getMember, impl, mem), mem);`);
     }
-    //pragma(msg, __LINE__, ": ", mixin(mem));
 }
 
-//public import impl;
-
 string untranslate(string name) {
-    return `auto ` ~ name ~ ` = ` ~ name ~ `_;`;
+    return `immutable ` ~ name ~ ` = ` ~ name ~ `_;`;
 }
 
 static foreach (name; ["METH_VARARGS", "METH_KEYWORDS", "METH_STATIC",

--- a/pynih/source/python/c.d
+++ b/pynih/source/python/c.d
@@ -44,8 +44,11 @@ template maybeAddAttributes(alias s, string name) {
     }
 }
 
+// I don't really understand why, but they aren't in the python library???
 enum ignore = ["PySignal_SetWakeupFd", "_PyCodec_Forget"];
 
+// go through all the members of the impl module and alias them, adding nothrow and nogc on
+// functions and functions pointers, but not on types
 static foreach (mem; __traits(allMembers, impl)) {
     static foreach (toIgnore; ignore) {
         static if (mem == toIgnore) {
@@ -67,6 +70,7 @@ static foreach (name; ["METH_VARARGS", "METH_KEYWORDS", "METH_STATIC",
     mixin(untranslate(name));
 }
 
+// can't initialise these at compile time, so do it at runtime
 static foreach(name; ["Py_None", "Py_True", "Py_False"]) {
     mixin(`PyObject* ` ~ name ~ `;`);
     shared static this() {
@@ -74,6 +78,7 @@ static foreach(name; ["Py_None", "Py_True", "Py_False"]) {
     }
 }
 
+/// hacky way to get the PyObject_HEAD macro safely correct
 mixin template PyObjectHead() {
     import impl : PyObject_HEAD_code;
     shared static this() {
@@ -82,6 +87,7 @@ mixin template PyObjectHead() {
     PyObject ob_base;
 }
 
+/// genuinely nice little abstraction
 auto pyObjectNew(T)(PyTypeObject* typeobj) {
     return cast(T*) _PyObject_New(typeobj);
 }


### PR DESCRIPTION
The build is a bit of a mess, very much in a "works on my machine" state.

But that's not why I'm sharing, why I'm sharing is because it shows `importC` working with LDC for building a python extension. It's nice not to need `libclang`.

But the biggest reason is to show how much crap is still necessary to wade through to get importC working for big things like python (especially when not using DMD with its convenient auto-importC feature).