### PR TITLE
Fix pynih/ci.sh script when $CI is not set

### DIFF
--- a/pynih/ci.sh
+++ b/pynih/ci.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 
 cd "$SCRIPT_DIR"
-if [ -z "$CI" ]; then
+if [ -z "${CI+x}" ]; then
     make -j"$(nproc)"
 else
     make


### PR DESCRIPTION
```
➜  autowrap (master) ✔ ./ci/test-all.sh                                                                                                                    
Testing with dmd compiler                                                                                                                                                    
/home/alexandrucm/workspace/autowrap/ci/../pynih/ci.sh: line 11: CI: unbound variable
```