### PR TITLE
Bump monty to 0.0.4

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"mirror": "0.3.2",
-		"monty": "0.0.1",
+		"monty": "0.0.4",
 		"unit-threaded": "2.0.3"
 	}
 }


### PR DESCRIPTION
Needed in order to add `autowrap` to Dlang's Buildkite.