### PR TITLE
Remove private attribute from PythonObject ctor

### DIFF
--- a/pynih/source/autowrap/pynih/python/object_.d
+++ b/pynih/source/autowrap/pynih/python/object_.d
@@ -14,7 +14,7 @@ struct PythonObject {
 
     // can only be used on Python C API calls that create a new PyObject*
     // due to reference count issues
-    private this(PyObject* obj) {
+    this(PyObject* obj) {
         _obj = obj;
     }
 


### PR DESCRIPTION
For some reason, this worked (and still works?) until now. Now Dlang's Buildkite build is broken:

```
tests/ut/pynih/python/object_.d(231,28): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(294,28): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(360,28): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(510,29): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(511,29): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(512,29): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
tests/ut/pynih/python/object_.d(517,33): Error: constructor `autowrap.pynih.python.object_.PythonObject.this` of type `ref PythonObject(_object* obj)` is not accessible from module `object_`
Error /buildkite/builds/b29a64f5a6d6-1/dlang/ci/buildkite-ci-build/distribution/bin/dmd failed with exit code 1.
🚨 Error: The command exited with status 2
user command error: exit status 2
```